### PR TITLE
breaking -> braking

### DIFF
--- a/BuggyReqs.tex
+++ b/BuggyReqs.tex
@@ -40,7 +40,7 @@
 	Each buggy shall pass a braking capability test, at least once each school semester, with each person who will be driving it, before that person will be permitted to drive that buggy in any type of practice session at
 	Carnegie Mellon University during that semester. 
 	
-	The purpose of the braking capability test is to ensure that each buggy meets a minimum breaking standard when moving in the forward direction, while a particular person is driving it.  The braking capability test shall be administered by the Safety Chairman, or anyone designated by that Chairman.
+	The purpose of the braking capability test is to ensure that each buggy meets a minimum braking standard when moving in the forward direction, while a particular person is driving it.  The braking capability test shall be administered by the Safety Chairman, or anyone designated by that Chairman.
 
 	The test shall take place on a flat, level, and smooth area, that is paved with either concrete or asphalt.If the area chosen is not completely level, the test shall be run in a direction such that the buggy being tested shall be moving toward the lower end of the area during the test. The sidewalk starting at Purnell and moving towards the University Center shall be used if it is available and in acceptable condition. If this area is not available or acceptable the Safety Chairman, or anyone designated by that Chairman, shall choose an alternate location for the test. A buggy may be tested for rearward braking at any time by the safety chairman as part of a spot safety check.
 


### PR DESCRIPTION
I got tasked with writing up a little summary of rule changes for the raceday preview and noticed this typo in your rule change (if you look before the rd24 PR it's correct). Sorry to be pedantic :') 